### PR TITLE
Switch player themes on the demo site without destroying

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -69,10 +69,10 @@
             <br>
             <div class="row">
                 <div class="large-4 small-12 large-centered small-centered columns skin-change-container">
-                    <a href="#" class="skin-change-btn active" id="light-btn" data-theme="light"></a>
-                    <a href="#" class="skin-change-btn" id="dark-btn" data-theme="dark"></a>
-                    <a href="#" class="skin-change-btn" id="aurora-btn" data-theme="aurora"></a>
-                    <a href="#" class="skin-change-btn" id="mojave-btn" data-theme="mojave"></a>
+                    <a href="#player" class="skin-change-btn active" id="light-btn" data-theme="light"></a>
+                    <a href="#player" class="skin-change-btn" id="dark-btn" data-theme="dark"></a>
+                    <a href="#player" class="skin-change-btn" id="aurora-btn" data-theme="aurora"></a>
+                    <a href="#player" class="skin-change-btn" id="mojave-btn" data-theme="mojave"></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Simply switch out the theme class on the player on-the-fly instead of destroying and recreating the player.

This makes for instantaneous switching of the themes, great way to show of the different themes without waiting for the recreation of the player.

Sorry about doing this to the `test/index.html`, but seemed to almost be the same as the production demo site.

Let me know what you think.
