### PR TITLE
fixed playlist type

### DIFF
--- a/sdk/js/player/network/soundcloud.js
+++ b/sdk/js/player/network/soundcloud.js
@@ -79,7 +79,7 @@ function resolve(track, tracksPerArtist, callback) {
                 return processTrack(item, function(err, track) {
                     return next(err, [track]);
                 });
-            } else if(item.kind === 'set') {
+            } else if(item.kind === 'playlist') {
                 return async.map(item.tracks, processTrack, next);
             } else if(item.kind === 'user') {
                 return getTracksForUser(item, tracksPerArtist, next);


### PR DESCRIPTION
There are four possible values of item.kind in the [soundcloud http api](https://developers.soundcloud.com/docs/api/reference#playlists):
* "playlist"
* "track"
* "user"
* "app"

The resolver returns "playlist" (not "set"), and playlists should work now